### PR TITLE
Fixed compilation errors for Angular Universal builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-cool-storage",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Cool Storage wrapper for angular2.",
   "main": "index.js",
   "peerDependencies": {

--- a/src/cool-local-storage.ts
+++ b/src/cool-local-storage.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@angular/core';
-import { CoolStorageBase } from './cool-storage-base'
+import { CoolStorageBase } from './cool-storage-base';
+
+/**
+ * PLATFORM_ID and isPlatformBrowser to determine if the window object exists in current context
+ */
+import { PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 @Injectable()
 export class CoolLocalStorage extends CoolStorageBase {
-  constructor() {
-    super(window.localStorage, 'LocalStorage');
+  constructor(@Inject(PLATFORM_ID) platformId: string) {
+      super((isPlatformBrowser(platformId) ? window.localStorage : [], 'LocalStorage');
   }
 }

--- a/src/cool-local-storage.ts
+++ b/src/cool-local-storage.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import {Injectable, Inject} from '@angular/core';
 import { CoolStorageBase } from './cool-storage-base';
 
 /**
@@ -7,9 +7,15 @@ import { CoolStorageBase } from './cool-storage-base';
 import { PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
+import { ServerStorage } from './server-storage';
+
 @Injectable()
 export class CoolLocalStorage extends CoolStorageBase {
-  constructor(@Inject(PLATFORM_ID) platformId: string) {
-      super((isPlatformBrowser(platformId) ? window.localStorage : [], 'LocalStorage');
+  constructor(@Inject(PLATFORM_ID) platformId: Object) {
+      if(isPlatformBrowser(platformId)) {
+          super(window.localStorage, 'LocalStorage');
+      }else{
+          super(new ServerStorage(), 'LocalStorage')
+      }
   }
 }

--- a/src/cool-local-storage.ts
+++ b/src/cool-local-storage.ts
@@ -15,7 +15,7 @@ export class CoolLocalStorage extends CoolStorageBase {
       if(isPlatformBrowser(platformId)) {
           super(window.localStorage, 'LocalStorage');
       }else{
-          super(new ServerStorage(), 'LocalStorage')
+          super(new ServerStorage(), 'LocalStorage');
       }
   }
 }

--- a/src/cool-session-storage.ts
+++ b/src/cool-session-storage.ts
@@ -15,7 +15,7 @@ export class CoolSessionStorage extends CoolStorageBase {
     if(isPlatformBrowser(platformId)) {
       super(window.sessionStorage, 'SessionStorage');
     }else{
-      super(new ServerStorage(), 'SessionStorage')
+      super(new ServerStorage(), 'SessionStorage');
     }
   }
 }

--- a/src/cool-session-storage.ts
+++ b/src/cool-session-storage.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import {Injectable, Inject} from '@angular/core';
 import { CoolStorageBase } from './cool-storage-base'
 
 /**
@@ -7,9 +7,15 @@ import { CoolStorageBase } from './cool-storage-base'
 import { PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
+import { ServerStorage } from './server-storage';
+
 @Injectable()
 export class CoolSessionStorage extends CoolStorageBase {
-  constructor(@Inject(PLATFORM_ID) platformId: string) {
-    super((isPlatformBrowser(platformId) ? window.sessionStorage : [], 'SessionStorage');
+  constructor(@Inject(PLATFORM_ID) platformId: Object) {
+    if(isPlatformBrowser(platformId)) {
+      super(window.sessionStorage, 'SessionStorage');
+    }else{
+      super(new ServerStorage(), 'SessionStorage')
+    }
   }
 }

--- a/src/cool-session-storage.ts
+++ b/src/cool-session-storage.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@angular/core';
 import { CoolStorageBase } from './cool-storage-base'
 
+/**
+ * PLATFORM_ID and isPlatformBrowser to determine if the window object exists in current context
+ */
+import { PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
 @Injectable()
 export class CoolSessionStorage extends CoolStorageBase {
-  constructor() {
-    super(window.sessionStorage, 'SessionStorage');
+  constructor(@Inject(PLATFORM_ID) platformId: string) {
+    super((isPlatformBrowser(platformId) ? window.sessionStorage : [], 'SessionStorage');
   }
 }

--- a/src/server-storage.ts
+++ b/src/server-storage.ts
@@ -1,0 +1,39 @@
+/**
+ * Created by nickv on 25-6-2017.
+ */
+export class ServerStorage {
+    private _storage : any;
+
+    public constructor(){
+        this._storage = {};
+    }
+
+    public getItem(key: string) : any {
+        if(this._storage.hasOwnProperty(key)) {
+            return this._storage.key;
+        }else{
+            return false;
+        }
+    }
+    
+    public removeItem(key: string) : boolean {
+        if(this._storage.hasOwnProperty(key)) {
+            delete this._storage.key;
+            return true;
+        }else{
+            return false;
+        }
+    }
+    
+    public key(index: number) : any {
+        return this._storage.key(index);
+    }
+    
+    public clear() {
+        this._storage = {};
+    }
+    
+    public setItem(key: string, value: string) : any {
+        this._storage[key] = value;
+    }
+}


### PR DESCRIPTION
Using the angular2-webpack-starter (found [here](https://github.com/qdouble/angular-webpack2-starter)) in combination with the Universal + AOT build with this module, there were errors thrown that `window is not defined`. This is correct, since the window object was accessed directly, not taking in account the Universal builds which start in NodeJS (serverside), where the window object does simply not exist.
I made a few small changes so that these errors no longer occur. Basically, the services `CoolSessionStorage` and `CoolLocalStorage` will inject the `platformId` and, by using this `platformId`, check is the code is ran serverside or clientside. If the code is ran serverside, it will use the newly `ServerStorage` class which is basically is basically an array that implements the LocalStorage specs till a certain point. Since code using the `LocalStorage` or `SessionStorage` is never actually used serverside (and runs again on clientside when the application boots there), there is no harm to be done by fixing it this way.
This code is tested on all builds including JIT, AOT and Universal and is also about to be used in production for my own applications. It would be nice to see this merged into the master branch.